### PR TITLE
Update Search functions to return a slice of pointers instead of pointer of a slice

### DIFF
--- a/album.go
+++ b/album.go
@@ -6,10 +6,12 @@ import (
 	mxmParams "github.com/milindmadhukar/go-musixmatch/params"
 )
 
-/*Get an album from Musixmatch's database: name, release_date, release_type, cover art.
+/*
+Get an album from Musixmatch's database: name, release_date, release_type, cover art.
 
 Parameters :
-    AlbumID - The musixmatch album id
+
+	AlbumID - The musixmatch album id
 */
 func (client *Client) GetAlbum(ctx context.Context, params ...mxmParams.Param) (*Album, error) {
 	var albumData album
@@ -24,16 +26,18 @@ func (client *Client) GetAlbum(ctx context.Context, params ...mxmParams.Param) (
 
 }
 
-/*Get the list of the songs of an album.
+/*
+Get the list of the songs of an album.
 
 Parameters:
-    AlbumID   - Musixmatch album id
-    AlbumMbId - Musicbrainz album id
-    HasLyrics - When set, filter only contents with lyrics
-    Page      - Define the page number for paginated results
-    PageSize  - Define the page size for paginated results. Range is 1 to 100.
+
+	AlbumID   - Musixmatch album id
+	AlbumMbId - Musicbrainz album id
+	HasLyrics - When set, filter only contents with lyrics
+	Page      - Define the page number for paginated results
+	PageSize  - Define the page size for paginated results. Range is 1 to 100.
 */
-func (client *Client) GetAlbumTracks(ctx context.Context, params ...mxmParams.Param) (*[]Track, error) {
+func (client *Client) GetAlbumTracks(ctx context.Context, params ...mxmParams.Param) ([]*Track, error) {
 	var tracksData trackList
 
 	err := client.get(ctx, "album.tracks.get", &tracksData, params...)
@@ -42,12 +46,12 @@ func (client *Client) GetAlbumTracks(ctx context.Context, params ...mxmParams.Pa
 		return nil, err
 	}
 
-	var tracks []Track
+	var tracks []*Track
 
 	for _, track := range tracksData.TrackList {
-		tracks = append(tracks, track.TrackData)
+		tracks = append(tracks, &track.TrackData)
 	}
 
-	return &tracks, nil
+	return tracks, nil
 
 }

--- a/artist.go
+++ b/artist.go
@@ -6,11 +6,13 @@ import (
 	mxmParams "github.com/milindmadhukar/go-musixmatch/params"
 )
 
-/*Get the artist data from Musixmatch's database.
+/*
+Get the artist data from Musixmatch's database.
 
 Parameters:
-    ArtistID   - Musixmatch artist id
-    ArtistMbID - Musicbrainz artist id
+
+	ArtistID   - Musixmatch artist id
+	ArtistMbID - Musicbrainz artist id
 */
 func (client *Client) GetArtist(ctx context.Context, params ...mxmParams.Param) (*Artist, error) {
 	var artistData artist
@@ -25,16 +27,18 @@ func (client *Client) GetArtist(ctx context.Context, params ...mxmParams.Param) 
 
 }
 
-/*Search for artists in Musixmatch's database.
+/*
+Search for artists in Musixmatch's database.
 
 Parameters:
-    QueryArtist - The song artist
-    ArtistID    - When set, filter by this artist id
-    ArtistMbID  - When set, filter by this artist musicbrainz id
-    Page        - Define the page number for paginated results
-    PageSize    - Define the page size for paginated results. Range is 1 to 100.
+
+	QueryArtist - The song artist
+	ArtistID    - When set, filter by this artist id
+	ArtistMbID  - When set, filter by this artist musicbrainz id
+	Page        - Define the page number for paginated results
+	PageSize    - Define the page size for paginated results. Range is 1 to 100.
 */
-func (client *Client) SearchArtist(ctx context.Context, params ...mxmParams.Param) (*[]Artist, error) {
+func (client *Client) SearchArtist(ctx context.Context, params ...mxmParams.Param) ([]*Artist, error) {
 
 	var artistsData artistList
 
@@ -44,27 +48,29 @@ func (client *Client) SearchArtist(ctx context.Context, params ...mxmParams.Para
 		return nil, err
 	}
 
-	var artists []Artist
+	var artists []*Artist
 
 	for _, artist := range artistsData.ArtistList {
-		artists = append(artists, artist.ArtistData)
+		artists = append(artists, &artist.ArtistData)
 	}
 
-	return &artists, nil
+	return artists, nil
 
 }
 
-/*Get the album discography of an artist
+/*
+Get the album discography of an artist
 
 Parameters:
-    ArtistID          - Musixmatch artist id
-    ArtistMbID        - Musicbrainz artist id
-    GroupByAlbumName  - Group by Album Name
-    SortByReleaseDate - Sort by release date (asc|desc)
-    Page              - Define the page number for paginated results
-    PageSize          - Define the page size for paginated results. Range is 1 to 100.
+
+	ArtistID          - Musixmatch artist id
+	ArtistMbID        - Musicbrainz artist id
+	GroupByAlbumName  - Group by Album Name
+	SortByReleaseDate - Sort by release date (asc|desc)
+	Page              - Define the page number for paginated results
+	PageSize          - Define the page size for paginated results. Range is 1 to 100.
 */
-func (client *Client) GetArtistAlbums(ctx context.Context, params ...mxmParams.Param) (*[]Album, error) {
+func (client *Client) GetArtistAlbums(ctx context.Context, params ...mxmParams.Param) ([]*Album, error) {
 
 	var albumsData albumList
 
@@ -74,25 +80,27 @@ func (client *Client) GetArtistAlbums(ctx context.Context, params ...mxmParams.P
 		return nil, err
 	}
 
-	var albums []Album
+	var albums []*Album
 
 	for _, album := range albumsData.AlbumList {
-		albums = append(albums, album.AlbumData)
+		albums = append(albums, &album.AlbumData)
 	}
 
-	return &albums, nil
+	return albums, nil
 
 }
 
-/*Get a list of artists somehow related to a given one.
+/*
+Get a list of artists somehow related to a given one.
 
 Parameters:
-    ArtistID          - Musixmatch artist id
-    ArtistMbID        - Musicbrainz artist id
-    Page              - Define the page number for paginated results
-    PageSize          - Define the page size for paginated results. Range is 1 to 100.
+
+	ArtistID          - Musixmatch artist id
+	ArtistMbID        - Musicbrainz artist id
+	Page              - Define the page number for paginated results
+	PageSize          - Define the page size for paginated results. Range is 1 to 100.
 */
-func (client *Client) GetRelatedArtists(ctx context.Context, params ...mxmParams.Param) (*[]Artist, error) {
+func (client *Client) GetRelatedArtists(ctx context.Context, params ...mxmParams.Param) ([]*Artist, error) {
 	var artistData artistList
 
 	err := client.get(ctx, "artist.related.get", &artistData, params...)
@@ -101,12 +109,12 @@ func (client *Client) GetRelatedArtists(ctx context.Context, params ...mxmParams
 		return nil, err
 	}
 
-	var artists []Artist
+	var artists []*Artist
 
 	for _, artist := range artistData.ArtistList {
-		artists = append(artists, artist.ArtistData)
+		artists = append(artists, &artist.ArtistData)
 	}
 
-	return &artists, nil
+	return artists, nil
 
 }

--- a/chart.go
+++ b/chart.go
@@ -6,14 +6,16 @@ import (
 	mxmParams "github.com/milindmadhukar/go-musixmatch/params"
 )
 
-/*Gets the API response of the top artists of a given country.
+/*
+Gets the API response of the top artists of a given country.
 
 Parameters:
-    Country   - A valid country code.
-    Page      - Define the page number for paginated results.
-    PageSize  - Define the page size for paginated results. Range is 1 to 100.
+
+	Country   - A valid country code.
+	Page      - Define the page number for paginated results.
+	PageSize  - Define the page size for paginated results. Range is 1 to 100.
 */
-func (client *Client) GetTopArtists(ctx context.Context, params ...mxmParams.Param) (*[]Artist, error) {
+func (client *Client) GetTopArtists(ctx context.Context, params ...mxmParams.Param) ([]*Artist, error) {
 
 	var artistsData artistList
 
@@ -23,13 +25,13 @@ func (client *Client) GetTopArtists(ctx context.Context, params ...mxmParams.Par
 		return nil, err
 	}
 
-	var artists []Artist
+	var artists []*Artist
 
 	for _, artist := range artistsData.ArtistList {
-		artists = append(artists, artist.ArtistData)
+		artists = append(artists, &artist.ArtistData)
 	}
 
-	return &artists, nil
+	return artists, nil
 
 }
 
@@ -37,17 +39,18 @@ func (client *Client) GetTopArtists(ctx context.Context, params ...mxmParams.Par
 Gets the API response of the top songs of a given country.
 
 Parameters:
-    Country    - A valid 2 letters country code. Set XW as worldwide
-    Page       - Define the page number for paginated results.
-    PageSize  - Define the page size for paginated results. Range is 1 to 100.
-    ChartName - Select among available charts:
-        top : editorial chart.
-        hot : Most viewed lyrics in the last 2 hours.
-        mxmweekly : Most viewed lyrics in the last 7 days.
-        mxmweekly_new : Most viewed lyrics in the last 7 days limited to new releases only.
-    HasLyrics - When set, filters only contents with lyrics.
+
+	Country    - A valid 2 letters country code. Set XW as worldwide
+	Page       - Define the page number for paginated results.
+	PageSize  - Define the page size for paginated results. Range is 1 to 100.
+	ChartName - Select among available charts:
+	    top : editorial chart.
+	    hot : Most viewed lyrics in the last 2 hours.
+	    mxmweekly : Most viewed lyrics in the last 7 days.
+	    mxmweekly_new : Most viewed lyrics in the last 7 days limited to new releases only.
+	HasLyrics - When set, filters only contents with lyrics.
 */
-func (client *Client) GetTopTracks(ctx context.Context, params ...mxmParams.Param) (*[]Track, error) {
+func (client *Client) GetTopTracks(ctx context.Context, params ...mxmParams.Param) ([]*Track, error) {
 
 	var tracksData trackList
 
@@ -57,12 +60,12 @@ func (client *Client) GetTopTracks(ctx context.Context, params ...mxmParams.Para
 		return nil, err
 	}
 
-	var tracks []Track
+	var tracks []*Track
 
 	for _, track := range tracksData.TrackList {
-		tracks = append(tracks, track.TrackData)
+		tracks = append(tracks, &track.TrackData)
 	}
 
-	return &tracks, nil
+	return tracks, nil
 
 }

--- a/music.go
+++ b/music.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Get the list of the music genres of Musixmatch's catalogue.
-func (client *Client) GetMusicGenres(ctx context.Context) (*[]MusicGenre, error) {
+func (client *Client) GetMusicGenres(ctx context.Context) ([]*MusicGenre, error) {
 	var genresData musicGenreList
 
 	err := client.get(ctx, "music.genres.get", &genresData)
@@ -14,12 +14,12 @@ func (client *Client) GetMusicGenres(ctx context.Context) (*[]MusicGenre, error)
 		return nil, err
 	}
 
-	var genres []MusicGenre
+	var genres []*MusicGenre
 
 	for _, genre := range genresData.MusicGenreList {
-		genres = append(genres, genre.MusicGenreData)
+		genres = append(genres, &genre.MusicGenreData)
 	}
 
-	return &genres, nil
+	return genres, nil
 
 }

--- a/musixmatch_test.go
+++ b/musixmatch_test.go
@@ -49,7 +49,7 @@ func TestGetAlbumTracks(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	assert((*album_tracks)[0].Name, "21", t)
+	assert(album_tracks[0].Name, "21", t)
 }
 
 func TestGetArtist(t *testing.T) {
@@ -70,7 +70,7 @@ func TestSearchArtist(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	assert((*artists)[0].Name, "Martin Garrix", t)
+	assert(artists[0].Name, "Martin Garrix", t)
 }
 
 func TestGetArtistAlbums(t *testing.T) {
@@ -79,7 +79,7 @@ func TestGetArtistAlbums(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	assert((*albums)[0].Name, "Greatest Hits Vol. 1", t)
+	assert(albums[0].Name, "Greatest Hits Vol. 1", t)
 }
 
 func TestGetMatcherLyrics(t *testing.T) {
@@ -134,7 +134,7 @@ func TestSearchTrack(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	assert((*tracks)[0].Name, "High On Life", t)
+	assert(tracks[0].Name, "High On Life", t)
 }
 
 func TestGetTrackLyrics(t *testing.T) {
@@ -173,7 +173,7 @@ func TestTopTracks(t *testing.T) {
 		params.Country("it"),
 	)
 
-  // TODO: Get tracks and test top
+	// TODO: Get tracks and test top
 
 	if err != nil {
 		t.Errorf(err.Error())

--- a/track.go
+++ b/track.go
@@ -25,12 +25,14 @@ Parameters:
 		FilterByMininiumReleaseDate - When set, filter the tracks with release date older than value, format is YYYYMMDD
 		SortByArtistRating          - Sort by our popularity index for artists (asc|desc)
 		SortByTrackRating           - Sort by our popularity index for tracks (asc|desc)
+
 TODO: what is quorum_factor?
-		quorum_factor                                - Search only a part of the given query string.Allowed range is (0.1 – 0.9)
-		Page                                         - Define the page number for paginated results
-		PageSize                                    - Define the page size for paginated results. Range is 1 to 100.
+
+	quorum_factor                                - Search only a part of the given query string.Allowed range is (0.1 – 0.9)
+	Page                                         - Define the page number for paginated results
+	PageSize                                    - Define the page size for paginated results. Range is 1 to 100.
 */
-func (client *Client) SearchTrack(ctx context.Context, params ...mxmParams.Param) (*[]Track, error) {
+func (client *Client) SearchTrack(ctx context.Context, params ...mxmParams.Param) ([]*Track, error) {
 
 	var trackData trackList
 
@@ -40,13 +42,13 @@ func (client *Client) SearchTrack(ctx context.Context, params ...mxmParams.Param
 		return nil, err
 	}
 
-	var tracks []Track
+	var tracks []*Track
 
 	for _, track := range trackData.TrackList {
-		tracks = append(tracks, track.TrackData)
+		tracks = append(tracks, &track.TrackData)
 	}
 
-	return &tracks, nil
+	return tracks, nil
 
 }
 
@@ -54,8 +56,9 @@ func (client *Client) SearchTrack(ctx context.Context, params ...mxmParams.Param
 Get a track info from musixmatch's database: title, artist, isrc(s), instrumental flag.
 
 Parameters:
-		CommonTrackID - The Musixmatch commontrack id
-		TrackISRC     - A valid ISRC identifier
+
+	CommonTrackID - The Musixmatch commontrack id
+	TrackISRC     - A valid ISRC identifier
 */
 func (client *Client) GetTrack(ctx context.Context, params ...mxmParams.Param) (*Track, error) {
 	var trackData track
@@ -74,8 +77,9 @@ func (client *Client) GetTrack(ctx context.Context, params ...mxmParams.Param) (
 Get the lyrics of a track.
 
 Parameters:
-		TrackID       - The Musixmatch track id
-		CommonTrackID - The Musixmatch commontrack id
+
+	TrackID       - The Musixmatch track id
+	CommonTrackID - The Musixmatch commontrack id
 */
 func (client *Client) GetTrackLyrics(ctx context.Context, params ...mxmParams.Param) (*Lyrics, error) {
 	var lyricsData lyrics
@@ -99,7 +103,8 @@ Get the snippet for a given track.
 A lyrics snippet is a very short representation of a song lyrics. It’s usually twenty to a hundred characters long and it’s calculated extracting a sequence of words from the lyrics.
 
 Parameters:
-		TrackID - The musixmatch track id
+
+	TrackID - The musixmatch track id
 */
 func (client *Client) GetTrackSnippet(ctx context.Context, params ...mxmParams.Param) (*Snippet, error) {
 


### PR DESCRIPTION
Slices are passed by ref. So, passing a ref of a ref only makes accessing the slice items harder. 
As pointed in the tests, we have to de-ref the slice to get the slice values. 
I've updated the implementation to return a slice of pointers to make the API uniformed and to make it easier to access.

- https://go.dev/tour/moretypes/8
- https://stackoverflow.com/questions/39993688/are-slices-passed-by-value